### PR TITLE
Allow simulations to run absent any HLP indicators

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -13,11 +13,24 @@ tar_map(
   values = tibble(scripts = fs::dir_ls("Data", glob = "*.R"),
                   names = fs::path_ext_remove(fs::path_file(scripts))),
   names = "names",
+  
+  # Load data
   tar_target(script, scripts, format = "file"),
   tar_target(data, callr::r(source, args = list(file = script))$value),
+  
+  # Run simulations
   tar_target(DS_Original, simulate_IRIS_metric(data)),
   tar_target(DS_Option1, simulate_composite(data)),
   tar_target(DS_Option2, simulate_criterion(data)),
   tar_target(DS_Option3, simulate_subcriterion(data)),
   tar_target(DS_Option4, simulate_cells(data)),
-  tar_target(DS_Option5, simulate_classifier(data)))
+  tar_target(DS_Option5, simulate_classifier(data)),
+  
+  # And again without the HLP indicators
+  tar_target(data_nohlp, select(data, -starts_with("I9"))),
+  tar_target(DS_Original_nohlp, simulate_IRIS_metric(data_nohlp)),
+  tar_target(DS_Option1_nohlp, simulate_composite(data_nohlp)),
+  tar_target(DS_Option2_nohlp, simulate_criterion(data_nohlp)),
+  tar_target(DS_Option3_nohlp, simulate_subcriterion(data_nohlp)),
+  tar_target(DS_Option4_nohlp, simulate_cells(data_nohlp)),
+  tar_target(DS_Option5_nohlp, simulate_classifier(data_nohlp)))

--- a/report-child.Rmd
+++ b/report-child.Rmd
@@ -1,0 +1,122 @@
+# {{str_to_sentence(dataset)}} Dataset
+
+```{r data-{{dataset}}}
+targets::tar_load(contains("{{dataset}}"))
+
+ds_options <- 
+  tribble(~label,                                ~opt,                    ~opt_nohlp,
+          "Pass/fail measure",                   DS_Original_{{dataset}}, DS_Original_nohlp_{{dataset}},
+          "1: Full composite",                   DS_Option1_{{dataset}},  DS_Option1_nohlp_{{dataset}},
+          "2: Composite at criterion level",     DS_Option2_{{dataset}},  DS_Option2_nohlp_{{dataset}},
+          "3: Composite at sub-criterion level", DS_Option3_{{dataset}},  DS_Option3_nohlp_{{dataset}},
+          "4: Comparison of homogenous cells",   DS_Option4_{{dataset}},  DS_Option4_nohlp_{{dataset}},
+          "5: Classifier/regression-based",      DS_Option5_{{dataset}},  DS_Option5_nohlp_{{dataset}})
+
+dict <- readxl::read_excel("Data/dict.xlsx", sheet = "{{dataset}}")
+```
+
+## Missingness plot
+
+```{r missing-{{dataset}}}
+naniar::vis_miss(data_hargeisa)
+```
+
+## Density simulations
+
+```{r density-{{dataset}}, fig.width=12, fig.height=12}
+pmap(ds_options,
+     ~ggplot(bind_rows("w/HLP" = ..2, "w/o HLP" = ..3, .id = "hlp"))+
+       geom_density(aes(x = DS_perc, fill = hlp), alpha = 0.5)+
+       geom_vline(aes(xintercept = mean_exited, color = hlp), 
+                  linetype = "dashed", size = 1, # alpha = 0.5,
+                  data = function(x) {x %>% group_by(hlp) %>% summarize(mean_exited = mean(DS_perc))})+
+       scale_x_continuous(labels = scales::label_percent()) +
+       theme_ipsum(plot_title_size = 13, base_size = 10)+
+       labs(x = "Simulated proportion overcoming vulnerabilities", y = "Simulation density", 
+            fill = NULL, color = NULL,
+            title = ..1)) %>% 
+  wrap_plots(ncol = 2) + plot_layout(guides = "collect") & theme(legend.position = "bottom")
+```
+
+## Indicators plot
+
+```{r indicators-{{dataset}}, fig.width=8, fig.height=6}
+indicator_hlp <-
+  ds_options$opt[-4] %>%
+  map(~lm(DS_perc*100 ~ .,
+          data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>%
+  map(broom::tidy, conf.int = TRUE) %>%
+  bind_rows() %>%
+  group_by(term) %>%
+  summarize(across(c(estimate, conf.low, conf.high), mean)) %>%
+  filter(term != "(Intercept)")
+
+indicator_nohlp <-
+  ds_options$opt_nohlp[-4] %>%
+  map(~lm(DS_perc*100 ~ .,
+          data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>%
+  map(broom::tidy, conf.int = TRUE) %>%
+  bind_rows() %>%
+  group_by(term) %>%
+  summarize(across(c(estimate, conf.low, conf.high), mean)) %>%
+  filter(term != "(Intercept)")
+
+indicator_data <-
+  bind_rows("w/ HLP" = indicator_hlp, "w/o HLP" = indicator_nohlp, .id = "hlp") %>%
+  mutate(term = str_replace(term, "^(I\\d+)", "")) %>%
+  left_join(dict, by = c(term = "variable")) %>%
+  mutate(term1 = str_c(indicator, label, sep = ": ") %>% fct_rev())
+
+ggplot(indicator_data,
+       aes(x=term1, y=estimate)) +
+  geom_hline(yintercept=0, colour="#8C2318", size=1) +  # Line at 0
+  geom_pointrange(aes(ymin=conf.low, ymax=conf.high, color = hlp), position = position_dodge(1)) +
+  labs(x="Indicator", y="Average effect estimate across metrices (in percentages of IDP stock)") +  # Labels
+  # viridis::scale_color_viridis(discrete = TRUE)+
+  # FIXME: what's the rational behind these magic constants?
+  geom_rect(aes(ymin=0.4, ymax= 0.82, xmin=0, xmax=Inf),
+            fill= "lightskyblue3",
+            alpha = 0.01) +
+  geom_rect(aes(ymin=-0.21, ymax= 0.23, xmin=0, xmax=Inf),
+            fill= "lightskyblue4",
+            alpha = 0.01) +
+  geom_rect(aes(ymin=1.1, ymax= 1.43, xmin=0, xmax=Inf),
+            fill= "lightskyblue",
+            alpha = 0.01) +
+  coord_flip() +  # Rotate the plot
+  theme_ipsum(plot_title_size = 13, base_size = 10)+
+  theme(legend.position = "bottom")
+```
+
+### Breakdown by Option
+
+```{r indicators-options-{{dataset}}, fig.width=8, fig.height=30}
+ds_options %>% 
+  filter(label != "3: Composite at sub-criterion level") %>% 
+  pmap(~list("w/ HLP" = ..2, "w/o HLP" = ..3) %>% 
+         map(~lm(DS_perc*100 ~ .,
+                 data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>% 
+         map(broom::tidy, conf.int = TRUE)) %>% 
+  map(~bind_rows(., .id = "hlp") %>% 
+        filter(term != "(Intercept)") %>% 
+        mutate(term = str_replace(term, "^(I\\d+)", "")) %>%
+        left_join(dict, by = c(term = "variable")) %>%
+        mutate(term1 = str_c(indicator, label, sep = ": ") %>% fct_rev())) %>% 
+  set_names(ds_options %>% filter(label != "3: Composite at sub-criterion level") %>% pull(label)) %>% 
+  imap(~ggplot(.x, aes(x=term1, y=estimate)) +
+         geom_hline(yintercept=0, colour="#8C2318", size=1) +  # Line at 0
+         geom_pointrange(aes(ymin=conf.low, ymax=conf.high, color = hlp), position = position_dodge(1)) +
+         labs(x="Indicator", y="Average effect estimate across metrices (in percentages of IDP stock)",
+              title = .y) +  # Labels
+         # FIXME: what's the rational behind these magic constants?
+         geom_rect(aes(ymin=0.4, ymax= 0.82, xmin=0, xmax=Inf),
+                   fill= "lightskyblue3", alpha = 0.01) +
+         geom_rect(aes(ymin=-0.21, ymax= 0.23, xmin=0, xmax=Inf),
+                   fill= "lightskyblue4", alpha = 0.01) +
+         geom_rect(aes(ymin=1.1, ymax= 1.43, xmin=0, xmax=Inf),
+                   fill= "lightskyblue", alpha = 0.01) +
+         coord_flip() +  # Rotate the plot
+         theme_ipsum(plot_title_size = 13, base_size = 10)+
+         theme(legend.position = "bottom")) %>% 
+  wrap_plots(ncol = 1) + plot_layout(guides = "collect") & theme(legend.position = "bottom")
+```

--- a/report.Rmd
+++ b/report.Rmd
@@ -1,6 +1,6 @@
 ---
-title: "IRIS Solutions Measures Simulations"
-subtitle: "Hargeisa dataset"
+title: "IRIS Solutions Measure"
+subtitle: "Overview of Simulation Results"
 output: html_document
 ---
 
@@ -9,81 +9,14 @@ library(tidyverse)
 library(hrbrthemes)
 library(patchwork)
 
-knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
+knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 knitr::opts_chunk$set(fig.align = "center")
 ```
 
-```{r data}
-targets::tar_load(contains("hargeisa"))
+```{r loop, results = 'asis'}
+datasets <- fs::dir_ls("Data", glob = "*.R") %>% fs::path_file() %>% fs::path_ext_remove()
 
-DS_Options <- list("Pass/fail measure" = DS_Original_hargeisa,
-                   "1: Full composite" = DS_Option1_hargeisa,
-                   "2: Composite at criterion level" = DS_Option2_hargeisa,
-                   "3: Composite at sub-criterion level" = DS_Option3_hargeisa,
-                   "4: Comparison of homogenous cells" = DS_Option4_hargeisa,
-                   "5: Classifier/regression-based" = DS_Option5_hargeisa)
+child_docs <- datasets %>% map(function(dataset) {knitr::knit_expand("report-child.Rmd")})
 
-dict <- readxl::read_excel("Data/dict.xlsx", sheet = "hargeisa")
+knitr::knit_child(text = unlist(child_docs), quiet = TRUE) %>% cat(sep = "\n")
 ```
-
-# Missingness plot
-
-```{r missing}
-naniar::vis_miss(data_hargeisa)
-```
-
-# Density simulations
-
-```{r density, fig.width=11, fig.height=8}
-DS_Options %>% 
-  imap(~ggplot(.x, aes(x=DS_perc))+
-         geom_density(fill="#0073C2FF", color="#e9ecef", alpha=0.8)+
-         geom_vline(aes(xintercept = mean(DS_perc)), 
-                    linetype = "dashed", size = 0.6, alpha = 0.5)+
-         theme_ipsum(plot_title_size = 13, base_size = 10)+
-         ggtitle(.y)+
-         xlab("Simulated proportion overcoming vulnerabilities")+
-         ylab("Simulation density")) %>% 
-  wrap_plots(ncol = 2)
-```
-
-# Indicators plot
-
-```{r indicators, fig.width=8, fig.height=5}
-indicator_data <- 
-  DS_Options[-4] %>% 
-  map(~lm(DS_perc*100 ~ ., 
-          data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>% 
-  map(broom::tidy, conf.int = TRUE) %>% 
-  bind_rows() %>% 
-  group_by(term) %>% 
-  summarize(across(c(estimate, conf.low, conf.high), mean)) %>% 
-  filter(term != "(Intercept)")
-
-indicator_data <- 
-  indicator_data %>% 
-  mutate(term = str_replace(term, "^(I\\d+)", "")) %>% 
-  left_join(dict, by = c(term = "variable")) %>% 
-  mutate(term1 = str_c(indicator, label, sep = ": ") %>% fct_rev())
-
-ggplot(indicator_data, 
-       aes(x=term1, y=estimate)) + 
-  geom_hline(yintercept=0, colour="#8C2318", size=1) +  # Line at 0
-  geom_pointrange(aes(ymin=conf.low, ymax=conf.high)) + 
-  labs(x="Indicator", y="Average effect estimate across metrices (in percentages of IDP stock)") +  # Labels
-  viridis::scale_color_viridis(discrete = TRUE)+
-  # FIXME: what's the rational behind these magic constants?
-  geom_rect(aes(ymin=0.4, ymax= 0.82, xmin=0, xmax=Inf),
-            fill= "lightskyblue3",
-            alpha = 0.01) +
-  geom_rect(aes(ymin=-0.21, ymax= 0.23, xmin=0, xmax=Inf),
-            fill= "lightskyblue4",
-            alpha = 0.01) +
-  geom_rect(aes(ymin=1.1, ymax= 1.43, xmin=0, xmax=Inf),
-            fill= "lightskyblue",
-            alpha = 0.01) + 
-  coord_flip() +  # Rotate the plot
-  theme_ipsum(plot_title_size = 13, base_size = 10)+
-  theme(legend.position = "none")
-```
-

--- a/simulations.R
+++ b/simulations.R
@@ -9,7 +9,7 @@ source("functions.R")
 future::plan(future::multisession)
 
 extract_indicators <- function(data) {
-  str_c("I", 1:10) %>% set_names() %>% map(~names(select(data, starts_with(paste0(., "_")))))
+  str_c("I", 1:10) %>% set_names() %>% map(~names(select(data, starts_with(paste0(., "_"))))) %>% discard(is_empty)
 }
 
 generate_combinations <- function(indicators) {


### PR DESCRIPTION
* Removed all explicit references to indicator variables from `functions.R` so that the simulations would run correctly without  HLP/I9 indicators.
* Updated `_targets.R` to run the simulations twice: first with the HLP indicators, and then again without them.
* Updated the skeleton `report.Rmd` to:
a. Display results disaggregated by the presence/absence of HLP indicators.
b. Display the effect of each indicator on the number of IDPs exiting the stock per metric since there's a lot of variation in the results between the different options which is not reflected in the aggregate plot.
c. Output the results from all datasets in one go so you don't have to keep changing variable names manually to see the results of the simulations for different datasets.