### PR TITLE
implement classifier threshold optimization, lasso regularization, and algorithmic clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This is a list of to-do steps that I would like to implement before we can be ce
 
 + Weighted calculations
 + Implement a tracking of WHICH IDPs are classified as overcoming vulnerabilities (Do the different metric options identify the same IDPs as no longer vulnerable?)
-+ Construction of homogenous cells: further explorations needed (!!!), could benefit from implementing a clustering algorithm to increase similiarity within IDP groups and dissimilarity betwen IDP groups
-+ Regression-based approach: further explorations needed, could use a lasso regularization, would need to test different cut-off points (!!!)
++ Construction of homogenous cells: further explorations needed (!!!)
++ Use bootstrap variance estimation to overcome challenge #3 (comparing IDPs to the survey point-estimate and using the bootstrap to estimate a confidence interval around the number of IDPs exiting the stock - only feasibly once there's some agreement on the choice of indicators, otherwise the simulations will take forever to run)
 + Create synergies with Kari-Anne's work on HLP indicators
 + More information on relation to progress measure and which indicators to use
 + Add communication that we should not choose a too lenient or too strict indicator set/metric

--- a/_targets.R
+++ b/_targets.R
@@ -24,7 +24,13 @@ tar_map(
   tar_target(DS_Option2, simulate_criterion(data)),
   tar_target(DS_Option3, simulate_subcriterion(data)),
   tar_target(DS_Option4, simulate_cells(data)),
+  tar_target(DS_Option4b, simulate_hclust(data)),
+  # tar_target(DS_Option4b_complete1, simulate_hclust(data, method = "complete", maxdiff = 1)),
+  # tar_target(DS_Option4b_complete2, simulate_hclust(data, method = "complete", maxdiff = 2)),
+  # tar_target(DS_Option4b_average1, simulate_hclust(data, method = "average", maxdiff = 1)),
+  # tar_target(DS_Option4b_average2, simulate_hclust(data, method = "average", maxdiff = 2)),
   tar_target(DS_Option5, simulate_classifier(data)),
+  tar_target(DS_Option5b, simulate_lasso(data)),
   
   # And again without the HLP indicators
   tar_target(data_nohlp, select(data, -starts_with("I9"))),
@@ -33,4 +39,10 @@ tar_map(
   tar_target(DS_Option2_nohlp, simulate_criterion(data_nohlp)),
   tar_target(DS_Option3_nohlp, simulate_subcriterion(data_nohlp)),
   tar_target(DS_Option4_nohlp, simulate_cells(data_nohlp)),
-  tar_target(DS_Option5_nohlp, simulate_classifier(data_nohlp)))
+  tar_target(DS_Option4b_nohlp, simulate_hclust(data_nohlp)),
+  # tar_target(DS_Option4b_nohlp_complete1, simulate_hclust(data_nohlp, method = "complete", maxdiff = 1)),
+  # tar_target(DS_Option4b_nohlp_complete2, simulate_hclust(data_nohlp, method = "complete", maxdiff = 2)),
+  # tar_target(DS_Option4b_nohlp_average1, simulate_hclust(data_nohlp, method = "average", maxdiff = 1)),
+  # tar_target(DS_Option4b_nohlp_average2, simulate_hclust(data_nohlp, method = "average", maxdiff = 2)),
+  tar_target(DS_Option5_nohlp, simulate_classifier(data_nohlp)),
+  tar_target(DS_Option5b_nohlp, simulate_lasso(data_nohlp)))

--- a/report-child.Rmd
+++ b/report-child.Rmd
@@ -10,7 +10,9 @@ ds_options <-
           "2: Composite at criterion level",     DS_Option2_{{dataset}},  DS_Option2_nohlp_{{dataset}},
           "3: Composite at sub-criterion level", DS_Option3_{{dataset}},  DS_Option3_nohlp_{{dataset}},
           "4: Comparison of homogenous cells",   DS_Option4_{{dataset}},  DS_Option4_nohlp_{{dataset}},
-          "5: Classifier/regression-based",      DS_Option5_{{dataset}},  DS_Option5_nohlp_{{dataset}})
+          "4b: Algorithmic clustering",          DS_Option4b_{{dataset}}, DS_Option4b_nohlp_{{dataset}},
+          "5: Classifier/regression-based",      DS_Option5_{{dataset}},  DS_Option5_nohlp_{{dataset}},
+          "5b: Lasso classifier",                DS_Option5b_{{dataset}}, DS_Option5b_nohlp_{{dataset}})
 
 dict <- readxl::read_excel("Data/dict.xlsx", sheet = "{{dataset}}")
 ```
@@ -42,7 +44,9 @@ pmap(ds_options,
 
 ```{r indicators-{{dataset}}, fig.width=8, fig.height=6}
 indicator_hlp <-
-  ds_options$opt[-4] %>%
+  ds_options %>% 
+  filter(!str_detect(label, "(3|5b):")) %>% 
+  pull(opt) %>% 
   map(~lm(DS_perc*100 ~ .,
           data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>%
   map(broom::tidy, conf.int = TRUE) %>%
@@ -52,7 +56,9 @@ indicator_hlp <-
   filter(term != "(Intercept)")
 
 indicator_nohlp <-
-  ds_options$opt_nohlp[-4] %>%
+  ds_options %>% 
+  filter(!str_detect(label, "(3|5b):")) %>% 
+  pull(opt) %>% 
   map(~lm(DS_perc*100 ~ .,
           data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>%
   map(broom::tidy, conf.int = TRUE) %>%
@@ -91,18 +97,18 @@ ggplot(indicator_data,
 ### Breakdown by Option
 
 ```{r indicators-options-{{dataset}}, fig.width=8, fig.height=30}
-ds_options %>% 
-  filter(label != "3: Composite at sub-criterion level") %>% 
-  pmap(~list("w/ HLP" = ..2, "w/o HLP" = ..3) %>% 
+ds_options %>%
+  filter(!str_detect(label, "(3|5b):")) %>% 
+  pmap(~list("w/ HLP" = ..2, "w/o HLP" = ..3) %>%
          map(~lm(DS_perc*100 ~ .,
-                 data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>% 
-         map(broom::tidy, conf.int = TRUE)) %>% 
-  map(~bind_rows(., .id = "hlp") %>% 
-        filter(term != "(Intercept)") %>% 
+                 data = select(., starts_with("I"), -any_of("iteration"), -where(~all(.==first(.))), DS_perc))) %>%
+         map(broom::tidy, conf.int = TRUE)) %>%
+  map(~bind_rows(., .id = "hlp") %>%
+        filter(term != "(Intercept)") %>%
         mutate(term = str_replace(term, "^(I\\d+)", "")) %>%
         left_join(dict, by = c(term = "variable")) %>%
-        mutate(term1 = str_c(indicator, label, sep = ": ") %>% fct_rev())) %>% 
-  set_names(ds_options %>% filter(label != "3: Composite at sub-criterion level") %>% pull(label)) %>% 
+        mutate(term1 = str_c(indicator, label, sep = ": ") %>% fct_rev())) %>%
+  set_names(ds_options %>% filter(!str_detect(label, "(3|5b):")) %>% pull(label)) %>%
   imap(~ggplot(.x, aes(x=term1, y=estimate)) +
          geom_hline(yintercept=0, colour="#8C2318", size=1) +  # Line at 0
          geom_pointrange(aes(ymin=conf.low, ymax=conf.high, color = hlp), position = position_dodge(1)) +
@@ -117,6 +123,6 @@ ds_options %>%
                    fill= "lightskyblue", alpha = 0.01) +
          coord_flip() +  # Rotate the plot
          theme_ipsum(plot_title_size = 13, base_size = 10)+
-         theme(legend.position = "bottom")) %>% 
+         theme(legend.position = "bottom")) %>%
   wrap_plots(ncol = 1) + plot_layout(guides = "collect") & theme(legend.position = "bottom")
 ```

--- a/simulations.R
+++ b/simulations.R
@@ -106,7 +106,18 @@ simulate_cells <- function(data) {
   cells %>% mutate(iteration = as.character(row_number())) %>% left_join(DS, by = "iteration")
 }
 
+# Option 4: Comparison of homogenous cells w/hclust ###########################################
+simulate_hclust <- function(data, method = "complete", maxdiff = 2) {
+  run_simulation(data, use_hclust, method = method, maxdiff = maxdiff)
+}
+
 # Option 5: Use a classifier ------------------------------------------------------------
 simulate_classifier <- function(data) {
   run_simulation(data, use_classifier)
+}
+
+# Option 5b: Use a classifier w/Lasso regularization  ----------------------------------------------------
+simulate_lasso <- function(data) {
+  tibble(DS = data %>% select(starts_with("I")) %>% use_lasso(),
+         DS_perc = DS/sum(data$ID))
 }


### PR DESCRIPTION
A few quick observations on the results:

* The classifier/regression-based approach gives smoother density distributions after implementing cut-off threshold optimization. The mean number of IDPs exiting the stock now is also closer to the mean under Option 1: Full Composite.
* It turns out the bi-modal distribution of the regression/classifier was a result of the presence of HLP process indicators (as opposed to outcome indicators). Since only IDPs can have access to HLP compensation/restitution mechanisms, having that as an indicator in the simulations results in practically all IDPs being classified as non-integrated (because the indicator perfectly separates the two populations).
* Lasso regularization (added as option 5b) doesn't seem to be a workable option. It ends up picking up too many indicators for some criteria while completely removing other criteria from the calculation which is a bit of difficult to justify.
* re algorithmic clustering (added as option 4b): while the average number of IDPs exiting the stock remains low across simulations, some indicator combinations result in >20% of the IDPs exiting the stock. The results are robust to choice of hierarchal clustering method (i.e., whether IDPs within a cluster differ at most or on average by a given number of indicators) and to the choice of number of indicators that could vary within a cluster (one or two). The default setting is to group IDPs so that they differ by at most two indicators within a cluster but I've left the other options commented out in `_targets.R` if you'd like to experiment with them. This tells us that option 4 is workable for certain combinations of indicators but we still need some theoretical justification for the groupings.

I'll work on tracking which IDPs are exiting the stock and update the report with the findings once that's done. 