### PR TITLE
reworked hargeisa

### DIFF
--- a/Data/hargeisa.R
+++ b/Data/hargeisa.R
@@ -3,165 +3,141 @@ library(tidyverse)
 # preparations ---------------------------------------------------------
 
 # read data
-hargeisa <- readxl::read_xlsx("Data/Hargeisa.xlsx", sheet = 3, guess_max = 15000)
+data <- readxl::read_xlsx("Data/Hargeisa.xlsx", sheet = "Data", guess_max = 15000)
+metadata <- readxl::read_xlsx("Data/Hargeisa.xlsx", sheet = "Metadata")
+
+data <- data |> filter(str_detect(hargeisa1, "Host|Displaced"))
+hargeisa_hh <- data |> select(hargeisa1, all_of(metadata |> filter(HouseInd == "house") |> pull(Name)), -hargeisa173, hargeisa179) |> distinct()
+hargeisa_ind <- data |> select(all_of(metadata |> filter(HouseInd == "ind") |> pull(Name)), hargeisa173)
 
 # identify idps vs hosts
-hargeisa <- hargeisa %>% 
-  filter(hargeisa1 != "Refugee returnee") %>% 
-  mutate(ID = ifelse(grepl("Displaced",hargeisa1)==T,1,0))
-
-# add household weights
-hargeisa <- hargeisa %>% rename(WT = hargeisa180)
+hargeisa_hh <- hargeisa_hh |> mutate(ID = as.numeric(hargeisa1 != "Host community"))
 
 # identify potential IASC indicators for each subcriteria -------------
 
 # 1.1 Victims of violence
 
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Proportion experiencing a security incident
     I1_sec_inc = case_when(
-      hargeisa127 == "No" ~ 0,
-      hargeisa127 == "Yes" ~ 1,
-      TRUE ~ NA_real_),
+      hargeisa127 == "No" ~ 1,
+      hargeisa127 == "Yes" ~ 0),
+    
     # Proportion feeling safe
     I1_sec_saf = case_when(
       hargeisa133 == "No" ~ 0,
       hargeisa133 == "Yes" ~ 1,
-      grepl("Only to some extent",hargeisa133) == T ~ 0,
-      TRUE ~ NA_real_),
-    # Proportion worried about theft, crime, or vandalism
-    I1_sec_wor = case_when(
-      is.na(hargeisa135) == T ~ 0,
-      is.na(hargeisa136) == T ~ 0,
-      is.na(hargeisa135) == F ~ 1,
-      is.na(hargeisa136) == F ~ 1,
-      TRUE ~ NA_real_
-    )
+      grepl("Only to some extent",hargeisa133) == T ~ 0),
   )
 
 # 1.2. Freedom of movement
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Problems visiting public places
     I2_move = case_when(
-      hargeisa137 == "No" ~ 0,
-      hargeisa137 == "Yes" ~ 1,
-      TRUE ~ NA_real_)
+      hargeisa137 == "No" ~ 1,
+      hargeisa137 == "Yes" ~ 0)
   )
 
 # 2.1. Food security 
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Inability to pay for food
     I3_pay_food = case_when(
-      hargeisa52 == "No" ~ 0,
-      hargeisa52 == "Yes" ~ 1,
-      TRUE ~ NA_real_),
+      hargeisa52 == "No" ~ 1,
+      hargeisa52 == "Yes" ~ 0),
+    
     # Number of meals per day
-    I3_meals = hargeisa59)
+    I3_meals = as.numeric(hargeisa59==3))
 
 # 2.2 Shelter and housing 
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Proportion living in overcrowded housing/shelter (> X persons per room)
-    I4_hous_overcrowd = ifelse(hargeisa14 > hargeisa103, 1, 0),
+    I4_hous_overcrowd = ifelse(hargeisa14/3 <= hargeisa103, 1, 0),
     
     # Proportion living in inadequate housing conditions (risk zones)
     I4_hous_inadequat = ifelse(hargeisa121 == "Yes"|
                                  hargeisa122 == "Yes"|
-                                 hargeisa123 == "Yes", 1, 0),
+                                 hargeisa123 == "Yes", 0, 1),
     
     # Proportion having access to electricity
     I4_hous_elect = case_when(
       hargeisa124 == "Yes" ~ 1,
-      hargeisa124 == "No" ~ 0,
-      TRUE ~ NA_real_),
+      hargeisa124 == "No" ~ 0),
     
-    # Proportion getting their drinking water from tank
-    I4_hous_water = ifelse(hargeisa126 == "Tank", 1, 0),
+    # Proportion having access to clean water
+    I4_hous_water = ifelse(hargeisa126 == "Tank" | hargeisa126 == "Bottled/bought", 1, 0),
     
     # Proportion having flushing toilet in household
-    I4_hous_toilet = ifelse(hargeisa109 == "Yes",1,0),
+    I4_hous_toilet = as.numeric(hargeisa109=="Yes"),
     
     # Proportion having bath/shower in household
-    I4_hous_bath = ifelse(hargeisa108 == "Yes",1,0)
+    I4_hous_bath = as.numeric(hargeisa108 == "Yes")
   )
 
 # 2.3 Medical services 
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     
     # Proportion with access to essential health care when needed. 
     I5_med_access = case_when(
       hargeisa67 == "Yes" & hargeisa73 == "Yes" ~ 1,
-      hargeisa67 != "Yes" & hargeisa73 == "No" ~ 0,
-      hargeisa67 == "No" ~ 0,
-      TRUE ~ NA_real_
-    ),
+      hargeisa67 == "Yes" & hargeisa73 == "No" ~ 0),
     
     # Births attended by skilled health personnel within 
     I5_med_birth = case_when(
-      hargeisa92 %in% c("Clinic","Hospital") ~ 1,
-      hargeisa92 %in% c("Home","Other") ~ 0,
       hargeisa93 %in% c("Doctor","Nurse/midwife") ~ 1,
       hargeisa93 %in% c("Family member","Traditional birth attendant") ~ 0,
-      TRUE ~ 1
-    ),
-    
+    ))
+
+hargeisa_ind <- hargeisa_ind |> 
+  mutate(
     # Child vaccinated
     I5_med_vac= case_when(
       hargeisa62 == "Yes" ~ 1, 
-      hargeisa62 == "No" ~ 0,
-      hargeisa62 == "Don't know" ~ 0,
-      is.na(hargeisa62) == T ~ 1, 
-      TRUE ~ NA_real_
-    ))
+      hargeisa62 == "No" ~ 0)
+  )
 
 # 2.4 Education 
-hargeisa <- hargeisa %>% 
+hargeisa_ind <- hargeisa_ind %>% 
   mutate(
     # Proportion children (5-17) is able to read
     I6_educ_child = case_when(hargeisa36 == "Yes" ~ 1,
-                              hargeisa36 == "No" ~ 0,
-                              is.na(hargeisa36)== T ~ 1),
-    # Proportion children (5-17) ever attending school
+                              hargeisa36 == "No" ~ 0),
+    
+    # Proportion children (5-17) ever attended school
     I6_ever_school = case_when(hargeisa37 == "Yes" ~ 1,
-                               hargeisa37 == "No" ~ 0,
-                               is.na(hargeisa37)== T ~ 1),
+                               hargeisa37 == "No" ~ 0),
+    
     # Proportion children (5-17) currently attending school
     I6_curr_school = case_when(hargeisa39 == "Yes" ~ 1,
-                               hargeisa39 == "No" ~ 0,
-                               is.na(hargeisa39)== T ~ 1),
+                               hargeisa39 == "No" ~ 0),
+    
     # proportion children (5-17) attending secondary school
     I6_sec_school = case_when(
-      hargeisa40 %in% c("Secondary school","University")~1, 
-      hargeisa38 %in% c("Secondary school","University")~1,
-      is.na(hargeisa$hargeisa40) == T ~ 1, 
-      is.na(hargeisa$hargeisa38) == T ~ 1, 
-      TRUE ~ 0),
-    # Proportion owning a mobile phone
-    I6_mobile_phone = ifelse(hargeisa111 == "Yes",1,0)
+      hargeisa40 %in% c("Secondary school","University", "Vocational")~1, 
+      !is.na(hargeisa40) ~ 0)
   )
 
 # 3.1 Employment and livelihoods
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Breadwinner in the family
     I7_breadwinner = ifelse(hargeisa166 > 0, 1, 0))
 
 # 3.2 Economic security 
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Proportion capable of unexpected expenses without borrowing money
-    I8_unexpect_expense = ifelse(hargeisa60 == "No",1,0), 
+    I8_unexpect_expense = as.numeric(hargeisa60 == "No"), 
+    
     # Proportion experiencing difficulties paying rent
     I8_rent_problems = case_when(
-      hargeisa100 == "Tenant" & hargeisa101 == "Yes" ~ 1, 
-      hargeisa100 == "Tenant" & hargeisa101 == "No" ~ 0, 
-      hargeisa100 != "Tenant" ~ 0, 
-      TRUE ~ NA_real_
-    ),
+      hargeisa100 == "Tenant" & hargeisa101 == "Yes" ~ 0, 
+      hargeisa100 == "Tenant" & hargeisa101 == "No" ~ 1),
+    
     # Average number of assets
     I8_assets_num = 
       ifelse(hargeisa105 == "Yes",1,0)+
@@ -174,57 +150,48 @@ hargeisa <- hargeisa %>%
   )
 
 # 4.1 Property restitution and compensation 
-hargeisa <- hargeisa %>% 
+hargeisa_hh <- hargeisa_hh %>% 
   mutate(
     # Proportion with documents to prove ownership of property left behind
-    I9_hlp_doc = 
+    I9_hlp_doc =
       case_when(
         ID == 0 ~ 1,
         ID == 1 & hargeisa118 == "Yes" ~ 1,
-        ID == 1 & hargeisa118 != "Yes" ~ 0,
-        hargeisa114 == "No" ~ 1, 
-        TRUE ~ NA_real_),
+        ID == 1 & (hargeisa118 == "No" | hargeisa118 == "Only partially") ~ 0),
+
     # Proportion with access to compensation mechanisms
-    I9_hlp_access = 
+    I9_hlp_access =
       case_when(
         ID == 0 ~ 1,
-        ID == 1 & grepl("Yes",hargeisa119)==T ~ 1,
-        ID == 1 & grepl("Yes",hargeisa119)==F ~ 0,
-        hargeisa114 == "No" ~ 1, 
-        TRUE ~ NA_real_), 
+        ID == 1 & grepl("Yes", hargeisa119) ~ 1,
+        ID == 1 & hargeisa119 == "No" ~ 0),
+
     # Proportion with effective restoration or compensation
-    I9_hlp_restored = 
+    I9_hlp_restored =
       case_when(
         ID == 0 ~ 1,
         ID == 1 & hargeisa120 == "Yes" ~ 1,
-        ID == 1 & hargeisa120 != "Yes" ~ 0,
-        hargeisa114 == "No" ~ 1, 
-        TRUE ~ NA_real_)
+        ID == 1 & str_detect(hargeisa120, "^No") ~ 0),
+    
+    # Proportion with written/registered tenure
+    I9_registered = as.numeric(str_detect(hargeisa113, "^Yes"))
   )
 
 # 5.1. Documentation 
-hargeisa <- hargeisa %>% 
+hargeisa_ind <- hargeisa_ind %>% 
   mutate(
     # Proportion with documents to prove identity 
-    I10_doc_id = ifelse(hargeisa42 == "Has a certificate"|
-                          hargeisa44 == "Yes" |
-                          hargeisa45 == "Yes" |
-                          hargeisa46 == "Yes", 1, 0),
+    I10_doc_id = case_when(hargeisa42 == "Has a certificate" |
+                             hargeisa44 == "Yes" |
+                             hargeisa45 == "Yes" |
+                             hargeisa46 == "Yes" ~ 1,
+                           hargeisa47 == "Yes" ~ 0),
     
     # Proportion with documents or access to replace missing documents if lost
     I10_doc_replace =  case_when(
-      hargeisa42 == "Has a certificate" ~ 1,  
-      hargeisa42 == "Never registered" ~ 0,  
-      hargeisa42 == "Registered at birth but no certificate" ~ 0, 
-      hargeisa44 == "Yes" ~ 1,
-      hargeisa44 == "No" ~ 0,
-      hargeisa45 == "Yes" ~ 1,
-      hargeisa45 == "No" ~ 0,
-      hargeisa46 == "Yes" ~ 1,
-      hargeisa46 == "No" ~ 0,
       hargeisa50 == "Yes" ~ 1,
       hargeisa50 == "No" ~ 0,
-      TRUE ~ NA_real_),
+      TRUE ~ I10_doc_id),
     
     # Proportion having a birth certificate
     I10_doc_birth = ifelse(hargeisa42 == "Has a certificate"|
@@ -236,62 +203,59 @@ hargeisa <- hargeisa %>%
 # prepare dataset for simulations -----------------------------------------------
 
 # define household characteristics
-hargeisa <- 
-  hargeisa %>% 
+hargeisa_hh <- 
+  hargeisa_hh |> 
   mutate(HH_disp_type = hargeisa1,
-         HH_gender = hargeisa3,
-         HH_origin_district = ifelse(is.na(hargeisa7)==T, "Unknown", hargeisa7),
-         HH_clan = ifelse(is.na(hargeisa13)==T, "Unknown", hargeisa13),
+         HH_origin_district = ifelse(is.na(hargeisa7), "Unknown", hargeisa7),
          HH_depart_yr = case_when(
            hargeisa28 <= 1990 ~ "Before 1990",
            hargeisa28 > 1990 & hargeisa28 <= 2000 ~ "Between 1990 and 2000",
            hargeisa28 > 2000 & hargeisa28 <= 2010 ~ "Between 2000 and 2010",
            hargeisa28 > 2010  ~ "After 2010",
-           TRUE ~ "Unknown"))
+           TRUE ~ "Unknown")) |> 
+  left_join(hargeisa_ind |> 
+              group_by(hargeisa179) |> 
+              summarize(
+                HH_gender = first(hargeisa3),
+                HH_clan = first(hargeisa13)))
 
-# select variables
-hargeisa <- hargeisa %>% select(-contains("hargeisa"))
+# aggregate individual-level data
+hargeisa_ind_child <- 
+  hargeisa_ind |> 
+  select(age = hargeisa10, matches("^I(5|6)"), hargeisa179) |> 
+  filter(between(age, 5, 17)) |> 
+  group_by(hargeisa179) |> 
+  summarize(across(matches("^I(5|6)"), ~all(.==1)))
 
-# unify direction of indicators: 1 for passing 
-hargeisa <- hargeisa %>% 
-  mutate(
-    I1_sec_inc = ifelse(I1_sec_inc == 1, 0,1),
-    I1_sec_saf = ifelse(I1_sec_saf == 1, 1,0),
-    I1_sec_wor = ifelse(I1_sec_wor == 1, 0,1),
-    I2_move = ifelse(I2_move == 1, 0,1),
-    I3_pay_food = ifelse(I3_pay_food == 1, 0,1),
-    I3_meals = ifelse(I3_meals < mean(I3_meals, na.rm = T), 0,1),
-    I4_hous_overcrowd = ifelse(I4_hous_overcrowd ==1, 0, 1),
-    I4_hous_inadequat = ifelse(I4_hous_inadequat ==1, 0, 1),
-    I4_hous_elect = ifelse(I4_hous_elect == 1, 1, 0),
-    I4_hous_water = ifelse(I4_hous_water ==1, 1, 0),
-    I4_hous_toilet = ifelse(I4_hous_toilet == 1 , 1, 0),
-    I4_hous_bath = ifelse(I4_hous_bath == 1 , 1, 0),
-    I5_med_access = ifelse(I5_med_access ==1, 1, 0),
-    I5_med_birth = ifelse(I5_med_birth == 1, 1, 0),
-    I5_med_vac = ifelse(I5_med_vac == 1, 1, 0),
-    I6_educ_child = ifelse(I6_educ_child ==1, 1, 0),
-    I6_ever_school = ifelse(I6_ever_school == 1, 1, 0),
-    I6_curr_school = ifelse(I6_curr_school == 1, 1, 0),
-    I6_sec_school = ifelse(I6_sec_school ==1, 1, 0),
-    I6_mobile_phone = ifelse(I6_mobile_phone == 1, 1, 0),
-    I7_breadwinner = ifelse(I7_breadwinner ==1, 1, 0),
-    I8_unexpect_expense = ifelse(I8_unexpect_expense == 1, 1, 0),
-    I8_rent_problems = ifelse(I8_rent_problems == 1, 0, 1),
-    I8_assets_num = ifelse(I8_assets_num >= mean(I8_assets_num, na.rm= T), 1, 0),
-    I9_hlp_doc = ifelse(I9_hlp_doc ==1, 1, 0),
-    I9_hlp_access = ifelse(I9_hlp_access ==1, 1, 0),
-    I9_hlp_restored = ifelse(I9_hlp_restored ==1, 1, 0),
-    I10_doc_id = ifelse(I10_doc_id ==1, 1, 0),
-    I10_doc_replace = ifelse(I10_doc_replace == 1, 1, 0),
-    I10_doc_birth = ifelse(I10_doc_birth == 1, 1, 0)
-  )
+hargeisa_ind_all <- 
+  hargeisa_ind |> 
+  group_by(hargeisa179) |> 
+  summarize(across(starts_with("I10"), ~all(.==1)))
+
+hargeisa_ind <- left_join(hargeisa_ind_all, hargeisa_ind_child) |> mutate(across(-hargeisa179, as.numeric))
+
+# combine household and individual data
+hargeisa <- left_join(hargeisa_hh |> select(ID, matches("^(I\\d+|HH)"), hargeisa179), hargeisa_ind)
+
+# convert numeric indicator to 1/0
+hargeisa <- 
+  hargeisa |> 
+  mutate(I8_assets_num = as.numeric(I8_assets_num >= (hargeisa |> filter(ID == 0) |> pull(I8_assets_num) |> mean(na.rm = TRUE))))
+
+# add household weights
+hargeisa <- hargeisa %>% mutate(WT = 1)
+
+# add household ID
+hargeisa <- hargeisa %>% rename(HHID = hargeisa179)
 
 # welfare-measure
 hargeisa <- hargeisa |> mutate(PERCAPITA = NA_real_)
 
-# add household ID
-hargeisa <- hargeisa %>% mutate(HHID = row_number())
+# select and reorder variables
+hargeisa <- 
+  hargeisa %>% 
+  select(-contains("hargeisa")) |> 
+  select(HHID, ID, WT, PERCAPITA, starts_with("HH_"), starts_with("I"))
 
 # final dataset ----
 hargeisa


### PR DESCRIPTION
Reworked to separate households from individuals. Same problem as Sudan: if we include the HLP indicators, ~90% of all IDP households can't be assessed. Remove them and you'd get much more reasonable exits rates even under the permissive metrics.

Haven't added the SDG indicators just yet. And algorithmic clustering no longer runs on this dataset with the HLP indicators present.